### PR TITLE
Add billing extractor Spring Boot project

### DIFF
--- a/billing-extractor/build.gradle
+++ b/billing-extractor/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.0'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.billing.extract'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(24)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/billing-extractor/src/main/java/com/billing/extract/BillingController.java
+++ b/billing-extractor/src/main/java/com/billing/extract/BillingController.java
@@ -1,0 +1,27 @@
+package com.billing.extract;
+
+import com.billing.extract.model.BillingInfo;
+import com.billing.extract.service.BillingExtractorService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/billing")
+public class BillingController {
+
+    private final BillingExtractorService service;
+
+    public BillingController(BillingExtractorService service) {
+        this.service = service;
+    }
+
+    @PostMapping(path = "/extract", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public BillingInfo extract(@RequestParam("file") MultipartFile file,
+                               @RequestParam("prompt") String prompt) throws IOException {
+        return service.extract(file, prompt);
+    }
+}

--- a/billing-extractor/src/main/java/com/billing/extract/BillingExtractorApplication.java
+++ b/billing-extractor/src/main/java/com/billing/extract/BillingExtractorApplication.java
@@ -1,0 +1,11 @@
+package com.billing.extract;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BillingExtractorApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BillingExtractorApplication.class, args);
+    }
+}

--- a/billing-extractor/src/main/java/com/billing/extract/model/BillingInfo.java
+++ b/billing-extractor/src/main/java/com/billing/extract/model/BillingInfo.java
@@ -1,0 +1,32 @@
+package com.billing.extract.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BillingInfo {
+    private double total;
+    private List<BillingItem> items = new ArrayList<>();
+
+    public BillingInfo() {}
+
+    public BillingInfo(double total, List<BillingItem> items) {
+        this.total = total;
+        this.items = items;
+    }
+
+    public double getTotal() {
+        return total;
+    }
+
+    public void setTotal(double total) {
+        this.total = total;
+    }
+
+    public List<BillingItem> getItems() {
+        return items;
+    }
+
+    public void setItems(List<BillingItem> items) {
+        this.items = items;
+    }
+}

--- a/billing-extractor/src/main/java/com/billing/extract/model/BillingItem.java
+++ b/billing-extractor/src/main/java/com/billing/extract/model/BillingItem.java
@@ -1,0 +1,29 @@
+package com.billing.extract.model;
+
+public class BillingItem {
+    private String description;
+    private double value;
+
+    public BillingItem() {}
+
+    public BillingItem(String description, double value) {
+        this.description = description;
+        this.value = value;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+}

--- a/billing-extractor/src/main/java/com/billing/extract/service/BillingExtractorService.java
+++ b/billing-extractor/src/main/java/com/billing/extract/service/BillingExtractorService.java
@@ -1,0 +1,39 @@
+package com.billing.extract.service;
+
+import com.billing.extract.model.BillingInfo;
+import com.billing.extract.model.BillingItem;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class BillingExtractorService {
+    private static final Pattern LINE_PATTERN = Pattern.compile("(.+?)\\s+(\\d+(?:\\.\\d+)?)");
+
+    public BillingInfo extract(MultipartFile file, String prompt) throws IOException {
+        List<BillingItem> items = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Matcher m = LINE_PATTERN.matcher(line);
+                if (m.find()) {
+                    String description = m.group(1).trim();
+                    double value = Double.parseDouble(m.group(2));
+                    items.add(new BillingItem(description, value));
+                }
+            }
+        }
+        double total = items.stream().mapToDouble(BillingItem::getValue).sum();
+        BillingInfo info = new BillingInfo();
+        info.setItems(items);
+        info.setTotal(total);
+        return info;
+    }
+}

--- a/billing-extractor/src/test/java/com/billing/extract/BillingExtractorApplicationTests.java
+++ b/billing-extractor/src/test/java/com/billing/extract/BillingExtractorApplicationTests.java
@@ -1,0 +1,12 @@
+package com.billing.extract;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BillingExtractorApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/billing-extractor/src/test/java/com/billing/extract/BillingExtractorServiceTests.java
+++ b/billing-extractor/src/test/java/com/billing/extract/BillingExtractorServiceTests.java
@@ -1,0 +1,26 @@
+package com.billing.extract;
+
+import com.billing.extract.model.BillingInfo;
+import com.billing.extract.service.BillingExtractorService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class BillingExtractorServiceTests {
+
+    @Autowired
+    BillingExtractorService service;
+
+    @Test
+    void simpleExtractionWorks() throws Exception {
+        String data = "ItemA 10\nItemB 5";
+        MockMultipartFile file = new MockMultipartFile("file", "sample.txt", "text/plain", data.getBytes());
+        BillingInfo info = service.extract(file, "test");
+        assertThat(info.getTotal()).isEqualTo(15);
+        assertThat(info.getItems()).hasSize(2);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'ftp-process'
+include 'billing-extractor'


### PR DESCRIPTION
## Summary
- add new `billing-extractor` Spring Boot module for parsing uploaded files
- implement `BillingExtractorService` to parse line items and totals
- expose `BillingController` with `/billing/extract` POST endpoint
- provide models for billing info and tests
- include new module in `settings.gradle`

## Testing
- `./gradlew test` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_b_685028d41d40832f938f52ea486d3541